### PR TITLE
Restrict deployments to main branch pushes

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -47,5 +47,6 @@ jobs:
 
     # Deploy to GitHub Pages
     - name: Deploy to GitHub Pages
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       id: deployment
       uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- gate the deploy-pages step behind a push-to-main condition to avoid deployments on pull requests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12de62f98832180b2ef6ad1b52cad