### PR TITLE
Add padding to markdown layout template

### DIFF
--- a/src/layouts/MarkdownLayout.astro
+++ b/src/layouts/MarkdownLayout.astro
@@ -9,11 +9,18 @@ const { frontmatter } = Astro.props;
         <section class="privacy-content">
             <div class="container">
                 <div class="content-wrapper">
-        <slot/>    
+        <slot/>
                 </div>
             </div>
         </section>
     </main>
-    
-    
+
+
 </Layout>
+
+<style>
+    .privacy-content {
+        padding-top: 50px;
+        padding-bottom: 30px;
+    }
+</style>


### PR DESCRIPTION
## Summary
- add vertical padding around markdown layout content so docs pages have breathing room

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68e62775cbe4832183f0f590362adc6e