### PR TITLE
Adjust ordered list alignment in Markdown layout

### DIFF
--- a/src/layouts/MarkdownLayout.astro
+++ b/src/layouts/MarkdownLayout.astro
@@ -23,4 +23,8 @@ const { frontmatter } = Astro.props;
         padding-top: 50px;
         padding-bottom: 30px;
     }
+
+    .content-wrapper ol {
+        padding-left: 1.5rem;
+    }
 </style>


### PR DESCRIPTION
## Summary
- add left padding to ordered lists rendered by MarkdownLayout for better alignment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6292da26c832193d4c473df1f20f9