### PR TITLE
Adjust ordered list spacing in Markdown layout

### DIFF
--- a/src/layouts/MarkdownLayout.astro
+++ b/src/layouts/MarkdownLayout.astro
@@ -25,6 +25,8 @@ const { frontmatter } = Astro.props;
     }
 
     .content-wrapper ol {
-        padding-left: 1.5rem;
+        padding-left: 1.75rem;
+        margin-left: 0;
+        margin-bottom: 1.5rem;
     }
 </style>


### PR DESCRIPTION
## Summary
- increase left padding on ordered lists in the Markdown layout to align numbers with text content
- add bottom margin to ordered lists so numbered lists have breathing room from surrounding content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e62bad77788321a82ed1e8953442a1